### PR TITLE
[FEAT]: record 페이지 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5711,6 +5711,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
       "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",

--- a/src/app/main/record/page.tsx
+++ b/src/app/main/record/page.tsx
@@ -10,6 +10,7 @@ import {StatusMessage} from '@/components/record/StatusMessage';
 import MicIcon from '@/assets/record/mic.svg';
 import {RecordFooter} from '@/components/record/RecordFooter';
 import {useRecord} from '@/hooks/useRecord';
+import {useSubmitSpeechMutation} from '@/hooks/queries/useSpeechQueries';
 
 type RecordStatus = 'idle' | 'recording' | 'paused';
 
@@ -20,11 +21,24 @@ type ToastState = {
 
 const INITIAL_TOAST_STATE: ToastState = {isVisible: false, message: ''};
 
+/**
+ * TODO: category는 사용자 선택 값이나 선택 UI(모달)가 아직 미구현이라 고정값 사용.
+ * title은 "날짜 + 카테고리" 형식으로 확정(별도 입력 UI 없음).
+ */
+const DEFAULT_CATEGORY = 'PRESENTATION';
+const createTitleParam = (category: string): string => {
+  const today = new Date().toISOString().slice(0, 10);
+  return `${today} ${category}`;
+};
+
 export default function RecordPage(): ReactElement {
   const router = useRouter();
 
   const {startRecording, pauseRecording, resumeRecording, stopRecording} =
     useRecord();
+
+  const {mutateAsync: submitSpeech, isPending: isSubmitting} =
+    useSubmitSpeechMutation();
 
   /**
    * idle: 대기 중, recording: 녹음 진행 중, paused: 일시정지됨
@@ -42,10 +56,29 @@ export default function RecordPage(): ReactElement {
     setToast((prev) => ({...prev, isVisible: false}));
   }, []);
 
+  /**
+   * 녹음을 종료하고 오디오를 업로드한 뒤 결과 로딩 페이지로 이동한다.
+   * stopRecording()은 recording/paused 상태 모두 정상 종료된다.
+   * 동적 라우트 경로로 다음 페이지에 전달한다
+   * 업로드 실패 시 라우팅하지 않고 토스트로 안내한다.
+   */
   const handleSubmit = useCallback(async (): Promise<void> => {
-    await stopRecording();
-    router.push(ROUTES.RESULT_LOADING);
-  }, [stopRecording, router]);
+    const audioBlob = await stopRecording();
+
+    try {
+      const speechId = await submitSpeech({
+        audio: audioBlob,
+        title: createTitleParam(DEFAULT_CATEGORY),
+        duration: elapsedSeconds,
+        category: DEFAULT_CATEGORY,
+      });
+
+      router.push(ROUTES.RESULT_LOADING(speechId));
+    } catch {
+      showToast('업로드에 실패했습니다. 다시 시도해 주세요');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stopRecording, submitSpeech, router, showToast]);
 
   /* 12분 경과 - 남은 시간 안내 토스트 */
   const handleWarning = useCallback((): void => {
@@ -89,6 +122,7 @@ export default function RecordPage(): ReactElement {
   };
 
   const handleSubmitClick = async (): Promise<void> => {
+    if (isSubmitting) return;
     await handleSubmit();
   };
 
@@ -128,6 +162,7 @@ export default function RecordPage(): ReactElement {
         status={status}
         elapsedSeconds={elapsedSeconds}
         isDanger={isDanger}
+        isSubmitting={isSubmitting}
         onPause={handlePauseClick}
         onResume={handleResumeClick}
         onSubmit={handleSubmitClick}

--- a/src/components/record/RecordFooter.tsx
+++ b/src/components/record/RecordFooter.tsx
@@ -7,6 +7,7 @@ interface RecordFooterProps {
   status: 'idle' | 'recording' | 'paused';
   elapsedSeconds: number;
   isDanger: boolean;
+  isSubmitting: boolean;
   onPause: () => void;
   onResume: () => void;
   onSubmit: () => void;
@@ -16,6 +17,7 @@ export const RecordFooter = ({
   status,
   elapsedSeconds,
   isDanger,
+  isSubmitting,
   onPause,
   onResume,
   onSubmit,
@@ -64,8 +66,8 @@ export const RecordFooter = ({
       <button
         className='bg-primary w-full rounded-[48px] py-4 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50'
         onClick={onSubmit}
-        disabled={status === 'idle'}>
-        제출하기
+        disabled={status === 'idle' || isSubmitting}>
+        {isSubmitting ? '제출 중...' : '제출하기'}
       </button>
     </footer>
   );

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -7,7 +7,7 @@ export const ROUTES = {
   HOMEPAGE: '/homepage',
   RECORD: '/main/record',
   RESULT: '/main/result',
-  RESULT_LOADING: '/main/loading',
+  RESULT_LOADING: (speechId: number) => `/main/loading/${speechId}`,
   RESULT_SHARE: '/main/share',
   MYPAGE: '/mypage',
   MYPAGE_STATS: '/mypage/stats',

--- a/src/hooks/queries/useSpeechQueries.ts
+++ b/src/hooks/queries/useSpeechQueries.ts
@@ -1,0 +1,13 @@
+/** 스피치 관련 React Query 훅 모음 */
+'use client';
+import {useMutation} from '@tanstack/react-query';
+import {postSpeechAzure} from '@/services/api/speech/speechApi';
+
+/**
+ * 스피치 분석 요청 mutation 훅.
+ * 성공 시 응답으로 speechId(number)를 반환한다.
+ */
+export const useSubmitSpeechMutation = () =>
+  useMutation({
+    mutationFn: postSpeechAzure,
+  });

--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -3,16 +3,16 @@
 import {useRef, useState} from 'react';
 
 /**
- * useRecord 커스텀 훅은 브라우저에서 오디오 녹음을 시작하고, 녹음이 완료되면 오디오 Blob URL을 반환합니다.
+ * useRecord 커스텀 훅은 브라우저에서 오디오 녹음을 시작하고, 녹음이 완료되면 오디오 Blob을 반환합니다.
  * @function useRecord
  * @returns {Object} 녹음 상태와 관련된 함수 및 데이터를 포함하는 객체.
  * @property {boolean} isRecording - 현재 녹음 중인지 여부를 나타냅니다. 녹음 중이면 true, 그렇지 않으면 false입니다.
  * @property {() => Promise<void>} startRecording - 녹음을 시작하는 비동기 함수입니다.
  *   사용자가 마이크 접근 권한을 허용해야 하며, 이 함수 호출 시 MediaRecorder가 초기화되고 녹음이 시작됩니다.
+ * @property {() => Promise<Blob>} stopRecording - 녹음을 중지하고 수집된 오디오 청크를
+ *   합쳐 Blob으로 반환하는 함수입니다. recording/paused 상태 모두 정상 종료됩니다.
  * @property {string} audio - 녹음이 종료된 후 생성된 오디오 파일의 Blob URL입니다.
  *   이 URL은 `<audio>` 태그의 src 속성 등에서 사용하여 녹음된 오디오를 재생할 수 있습니다.
- * @property {() => void} stopRecording - 녹음을 중지하는 함수입니다.
- *   녹음이 중지되면, 현재까지 수집된 오디오 청크를 기반으로 Blob이 생성되고, 해당 Blob의 URL이 상태에 저장됩니다.
  */
 
 export function useRecord(): {
@@ -20,14 +20,14 @@ export function useRecord(): {
   startRecording: () => Promise<void>;
   pauseRecording: () => void;
   resumeRecording: () => void;
-  stopRecording: () => Promise<string>;
+  stopRecording: () => Promise<Blob>;
   audio: string;
 } {
   const [isRecording, setIsRecording] = useState<boolean>(false);
   const [audio, setAudio] = useState<string>('');
   const mediaRecorderRef = useRef<MediaRecorder>(null);
   const audioChunksRef = useRef<Blob[]>([]);
-  const recordingPromiseRef = useRef<(value: string) => void>(() => {});
+  const recordingPromiseRef = useRef<(value: Blob) => void>(() => {});
   const streamRef = useRef<MediaStream>(null);
 
   const startRecording = async () => {
@@ -55,7 +55,7 @@ export function useRecord(): {
         });
         const audioUrl = URL.createObjectURL(audioBlob);
         setAudio(audioUrl);
-        recordingPromiseRef.current?.(audioUrl);
+        recordingPromiseRef.current?.(audioBlob);
       };
 
       mediaRecorderRef.current.start();
@@ -85,8 +85,8 @@ export function useRecord(): {
     }
   };
 
-  const stopRecording = (): Promise<string> => {
-    return new Promise<string>((resolve) => {
+  const stopRecording = (): Promise<Blob> => {
+    return new Promise<Blob>((resolve) => {
       recordingPromiseRef.current = resolve;
 
       if (streamRef.current) {

--- a/src/services/api/speech/speechApi.ts
+++ b/src/services/api/speech/speechApi.ts
@@ -1,0 +1,36 @@
+/** 스피치 관련 API 호출 함수 모음 */
+import {api} from '@/services/lib/axios';
+import {API_ENDPOINTS} from '@/services/constant/endpoint';
+
+interface PostSpeechAzureRequest {
+  audio: Blob;
+  title: string;
+  duration: number;
+  category: string;
+}
+
+/** POST /api/speech/azure 응답: 생성된 speechId */
+type PostSpeechAzureResponse = number;
+
+/**
+ * 스피치 분석을 요청한다.
+ * 오디오는 multipart/form-data body로, title/duration/category는
+ * query parameter로 전송한다.
+ */
+export const postSpeechAzure = async ({
+  audio,
+  title,
+  duration,
+  category,
+}: PostSpeechAzureRequest): Promise<PostSpeechAzureResponse> => {
+  const formData = new FormData();
+  formData.append('audio', audio, 'recording.wav');
+
+  const response = await api.post<PostSpeechAzureResponse>(
+    API_ENDPOINTS.speech.azure,
+    formData,
+    {params: {title, duration, category}}
+  );
+
+  return response.data;
+};

--- a/src/services/lib/axios.ts
+++ b/src/services/lib/axios.ts
@@ -11,6 +11,9 @@ export const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('accessToken');
   if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (config.data instanceof FormData) {
+    delete config.headers['Content-Type'];
+  }
   return config;
 });
 


### PR DESCRIPTION
## 🔗 관련 이슈

closes #43

## 📝 작업 내용

- record 페이지에 음성 녹음 제출부터 분석 요청까지 이어지는 speech 분석 API(`POST /api/speech/azure`)를 연동했습니다.
- 녹음 종료 시 오디오를 서버에 업로드하고, 응답으로 받은 `speechId`를 결과 로딩 페이지로 전달하는 전체 흐름을 구현했습니다.
- 오디오 파일 전송을 위해 axios 인스턴스가 FormData 요청 시 `Content-Type`을 자동 설정하도록 개선했습니다.

## ✅ 체크리스트

### #43 record 페이지 API 연동

- [x] speech 분석 API 호출 함수(`postSpeechAzure`) 추가 — 오디오는 `multipart/form-data`, `title`/`duration`/`category`는 query parameter로 전송
- [x] `useSubmitSpeechMutation` 커스텀 훅 기반의 녹음 제출 및 분석 요청 로직 구현
- [x] FormData 전송 시 `Content-Type`이 자동 설정되도록 axios 요청 인터셉터 수정
- [x] 서버 업로드를 위해 `stopRecording`이 Blob URL 대신 Blob 객체를 반환하도록 변경
- [x] 녹음 제출 후 응답으로 받은 `speechId`를 결과 로딩 페이지로 전달하는 라우팅 연동
- [x] 업로드 진행 중 제출 버튼 비활성화 및 중복 제출 방지 처리 구현
- [x] `RESULT_LOADING` 라우트를 `speechId` 기반 동적 경로로 변경

## 📌 비고
- `title`은 백엔드와 협의된 "날짜 + 카테고리" 형식으로 전송하며, `category`는 선택 UI 미구현으로 현재 `PRESENTATION` 고정값을 사용합니다.

## 이후 진행사항
- Header.tsx blob 에러
- 녹음 파일 WAV 형식으로 전달되도록 수정
- category 선택 UI 구현