### PR TITLE
[FEAT]: record 녹음 파일 WAV 형식 변환 및 전송

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.100.11",
+        "audiobuffer-to-wav": "^1.0.0",
         "axios": "^1.16.1",
         "framer-motion": "^12.38.0",
         "html-to-image": "^1.11.13",
@@ -5682,6 +5683,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/audiobuffer-to-wav": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/audiobuffer-to-wav/-/audiobuffer-to-wav-1.0.0.tgz",
+      "integrity": "sha512-CAoir4NRrAzAgYo20tEMiKZR84coE8bq/L+H2kwAaULVY4+0xySsEVtNT5raqpzmH6y0pqzY6EmoViLd9W8F/w==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.100.11",
+    "audiobuffer-to-wav": "^1.0.0",
     "axios": "^1.16.1",
     "framer-motion": "^12.38.0",
     "html-to-image": "^1.11.13",

--- a/src/app/main/record/page.tsx
+++ b/src/app/main/record/page.tsx
@@ -70,11 +70,7 @@ export default function RecordPage(): ReactElement {
    * 업로드 실패 시 라우팅하지 않고 토스트로 안내한다.
    */
   const handleSubmit = useCallback(async (): Promise<void> => {
-    //시연용: public/test.wav 파일 사용
-    // const audioBlob = await stopRecording();
-    // console.log(audioBlob.type);
-    const response = await fetch('/record/test.wav');
-    const audioBlob = await response.blob();
+    const audioBlob = await stopRecording();
 
     try {
       const speechId = await submitSpeech({

--- a/src/components/mypage/ProfileSection.tsx
+++ b/src/components/mypage/ProfileSection.tsx
@@ -49,7 +49,6 @@ export const ProfileSection = ({profile}: ProfileSectionProps) => {
 
     const previewUrl = URL.createObjectURL(file);
     setImageUrl(previewUrl);
-    setUser({profileImage: previewUrl});
   };
 
   const handleNameMenuClick = (): void => {

--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import {useRef, useState} from 'react';
+import audioBufferToWav from 'audiobuffer-to-wav';
 
 /**
  * useRecord 커스텀 훅은 브라우저에서 오디오 녹음을 시작하고, 녹음이 완료되면 오디오 Blob을 반환합니다.
@@ -28,6 +29,7 @@ export function useRecord(): {
   const mediaRecorderRef = useRef<MediaRecorder>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const recordingPromiseRef = useRef<(value: Blob) => void>(() => {});
+  const recordingRejectRef = useRef<(reason: Error) => void>(() => {});
   const streamRef = useRef<MediaStream>(null);
 
   const startRecording = async () => {
@@ -49,13 +51,25 @@ export function useRecord(): {
         }
       };
 
-      mediaRecorderRef.current.onstop = () => {
-        const audioBlob = new Blob(audioChunksRef.current, {
-          type: 'audio/wav',
-        });
-        const audioUrl = URL.createObjectURL(audioBlob);
-        setAudio(audioUrl);
-        recordingPromiseRef.current?.(audioBlob);
+      mediaRecorderRef.current.onstop = async () => {
+        try {
+          const recordedBlob = new Blob(audioChunksRef.current);
+          const arrayBuffer = await recordedBlob.arrayBuffer();
+          const audioContext = new AudioContext();
+          const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+          await audioContext.close();
+
+          const wavArrayBuffer = audioBufferToWav(audioBuffer);
+          const wavBlob = new Blob([wavArrayBuffer], {type: 'audio/wav'});
+
+          const audioUrl = URL.createObjectURL(wavBlob);
+          setAudio(audioUrl);
+          recordingPromiseRef.current?.(wavBlob);
+        } catch (e) {
+          recordingRejectRef.current?.(
+            e instanceof Error ? e : new Error('WAV 변환에 실패했습니다')
+          );
+        }
       };
 
       mediaRecorderRef.current.start();
@@ -86,8 +100,9 @@ export function useRecord(): {
   };
 
   const stopRecording = (): Promise<Blob> => {
-    return new Promise<Blob>((resolve) => {
+    return new Promise<Blob>((resolve, reject) => {
       recordingPromiseRef.current = resolve;
+      recordingRejectRef.current = reject;
 
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((track) => {

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -28,6 +28,7 @@ export const useUserStore = create<UserState>()(
     }),
     {
       name: 'user-storage',
+      partialize: (state) => ({nickname: state.nickname}),
     }
   )
 );

--- a/src/types/audioBufferToWav.d.ts
+++ b/src/types/audioBufferToWav.d.ts
@@ -1,0 +1,11 @@
+declare module 'audiobuffer-to-wav' {
+  /**
+   * AudioBuffer를 WAV 포맷의 ArrayBuffer로 변환한다.
+   * @param buffer 변환할 AudioBuffer
+   * @param options float 옵션 등 (생략 가능)
+   */
+  export default function audioBufferToWav(
+    buffer: AudioBuffer,
+    options?: {float32?: boolean}
+  ): ArrayBuffer;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #48

## 📝 작업 내용
- record 페이지에서 녹음한 오디오를 실제 WAV 형식으로 변환해 서버로 전송하도록 수정했습니다.
- 기존에는 MediaRecorder가 생성한 청크에 `audio/wav` 라벨만 붙여 전송해, 실제 데이터는 webm/m4a 형식으로 업로드되는 문제가 있었습니다. 
- Azure가 WAV를 기본 포맷으로 받기 때문에, 녹음 데이터를 디코딩 후 WAV로 인코딩하여 전송하도록 변경했습니다.

## ✅ 체크리스트
### #48 record 녹음 파일 WAV 형식 변환

- [x] audiobuffer-to-wav 패키지 추가 및 모듈 타입 선언 파일 작성
- [x] 녹음 청크를 AudioContext로 디코딩 후 WAV로 변환하는 로직 구현
- [x] `stopRecording`이 실제 WAV Blob을 반환하도록 수정
- [x] WAV 변환 실패 시 `stopRecording` Promise를 reject하여 예외 처리
- [x] record 페이지의 제출 로직을 시연용 고정 파일에서 실제 녹음(`stopRecording`)으로 변경
- [x] 프로필 이미지 blob URL 영구 저장 문제 수정] 

## 📌 비고
- 녹음 → WAV 변환 → 업로드 → 분석 결과 페이지까지 전체 흐름 동작을 확인했습니다.
- MediaRecorder는 WAV를 직접 생성하지 못해, 디코딩 후 재인코딩하는 방식으로 변환합니다.