### PR TITLE
[FIX}: API 프록시 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,14 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.API_BASE_URL}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/services/constant/endpoint.ts
+++ b/src/services/constant/endpoint.ts
@@ -1,6 +1,4 @@
 /** API 엔드포인트 URL 모음 */
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
 export const API_ENDPOINTS = {
   auth: {
     quickSignup: '/api/test/quick-signup',

--- a/src/services/lib/axios.ts
+++ b/src/services/lib/axios.ts
@@ -1,9 +1,8 @@
 /** axios 인스턴스 기본 설정 파일 */
-import {API_BASE_URL} from '@/services/constant/endpoint';
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: '/',
   headers: {'Content-Type': 'application/json'},
 });
 


### PR DESCRIPTION
## 문제
vercel(HTTPS)에서 EC2 백엔드(HTTP)로 직접 요청 시 `Mixed Content` 오류로 API 호출이 차단됨

## 원인
NEXT_PUBLIC_API_BASE_URL은 브라우저에 노출되는 변수로 브라우저가 직접 URL으로 요청을 시도함
HTTPS 페이지에서 HTTP 리소스를 요청하면 브라우저가 보안상 차단함

## 해결
- 프론트 서버 도메인을 구매하는 방법이 있으나 비용이 따로 들어가므로 `NEXT_PUBLIC_API_BASE_URL`을 `API_BASE_URL`로 변경 (직접 호출 불가능)
- next.config.ts에 rewrites 설정 추가로 프록시 구성

## 요청사항
변경된 `env.local` 파일은 노션에 올려두었습니다
실행시 next 타입 에러가 뜬다면 .next 폴더 삭제 후 재실행하면 됩니다