### PR TITLE
[FEAT]: 학습 수준 페이지 api 연동

### DIFF
--- a/src/app/mypage/difficulty/page.tsx
+++ b/src/app/mypage/difficulty/page.tsx
@@ -2,20 +2,20 @@
 
 import {useRouter} from 'next/navigation';
 import {DifficultySelectionList} from '@/components/difficulty/DifficultySelectionList';
+import {Spinner} from '@/components/common/Spinner';
 import {ROUTES} from '@/constants/routes';
-import type {DifficultyLevel} from '@/constants/difficulty';
-import {mockDifficultyLevel} from '@/mocks/mypage';
+import {GRADE_CODE_TO_LABEL} from '@/constants/difficulty';
+import {useUserInfo} from '@/hooks/queries/useUser';
 
 /**
- * - 현재 학습 수준이 미리 선택되어 있다.
+ * - 현재 학습 수준을 서버에서 조회해 미리 선택되어 있다.
  * - 변경 완료 시 마이페이지로 돌아간다.
  */
 export default function MypageDifficultyPage() {
   const router = useRouter();
+  const {data: userInfo, isLoading, isError, refetch} = useUserInfo();
 
-  const handleConfirm = (level: DifficultyLevel): void => {
-    /* TODO: 학습 수준 변경 API 연동 */
-    console.log('학습 수준 변경:', level);
+  const handleConfirm = (): void => {
     router.push(ROUTES.MYPAGE);
   };
 
@@ -38,11 +38,27 @@ export default function MypageDifficultyPage() {
           </p>
         </header>
 
-        <DifficultySelectionList
-          initialSelected={mockDifficultyLevel}
-          buttonText='변경 완료'
-          onConfirm={handleConfirm}
-        />
+        {isLoading ? (
+          <Spinner />
+        ) : isError || !userInfo ? (
+          <div className='flex flex-col items-center gap-4 pt-8'>
+            <p className='text-primary2 text-base font-semibold'>
+              정보를 불러오지 못했습니다. 다시 시도해 주세요
+            </p>
+            <button
+              type='button'
+              onClick={() => refetch()}
+              className='bg-primary rounded-full px-8 py-3 text-base font-semibold text-white transition'>
+              다시 시도
+            </button>
+          </div>
+        ) : (
+          <DifficultySelectionList
+            initialSelected={GRADE_CODE_TO_LABEL[userInfo.targetLevel]}
+            buttonText='변경 완료'
+            onConfirm={handleConfirm}
+          />
+        )}
       </div>
     </main>
   );

--- a/src/app/mypage/difficulty/page.tsx
+++ b/src/app/mypage/difficulty/page.tsx
@@ -41,7 +41,7 @@ export default function MypageDifficultyPage() {
         {isLoading ? (
           <Spinner />
         ) : isError || !userInfo ? (
-          <div className='flex flex-col items-center gap-4 pt-8'>
+          <div className='flex flex-col items-center gap-4'>
             <p className='text-primary2 text-base font-semibold'>
               정보를 불러오지 못했습니다. 다시 시도해 주세요
             </p>

--- a/src/components/difficulty/DifficultySelectionList.tsx
+++ b/src/components/difficulty/DifficultySelectionList.tsx
@@ -2,10 +2,12 @@
 
 import {useState} from 'react';
 import {useRouter} from 'next/navigation';
+import Toast from '@/components/common/Toast';
 import {DifficultyCard} from '@/components/difficulty/DifficultyCard';
-import {DIFFICULTY_OPTIONS} from '@/constants/difficulty';
+import {DIFFICULTY_OPTIONS, GRADE_LABEL_TO_CODE} from '@/constants/difficulty';
 import type {DifficultyLevel} from '@/constants/difficulty';
 import {ROUTES} from '@/constants/routes';
+import {useUpdateUserGradeMutation} from '@/hooks/queries/useUser';
 
 interface DifficultySelectionListProps {
   initialSelected?: DifficultyLevel | null;
@@ -14,8 +16,10 @@ interface DifficultySelectionListProps {
 }
 
 /**
- * - 학년 선택 후 학습 시작하기 버튼 클릭 시 홈페이지로 이동
- * - TODO: 학습 수준 저장 API 연동 (PATCH /api/users/me/grade) 추후 구현 예정
+ * 학습 수준 선택 리스트.
+ * 선택한 학년을 PATCH /api/users/me/grade로 저장한다.
+ * - 가입 플로우: 저장 성공 시 홈페이지로 이동한다.
+ * - 마이페이지 변경: onConfirm을 넘기면 저장 성공 후 onConfirm이 호출되어 마이페이지로 복귀한다.
  */
 export const DifficultySelectionList = ({
   initialSelected = null,
@@ -26,23 +30,42 @@ export const DifficultySelectionList = ({
   const [selectedLevel, setSelectedLevel] = useState<DifficultyLevel | null>(
     initialSelected
   );
+  const [isToastVisible, setIsToastVisible] = useState<boolean>(false);
+
+  const {mutateAsync: updateGrade, isPending} = useUpdateUserGradeMutation();
 
   const handleCardSelect = (level: DifficultyLevel): void => {
     setSelectedLevel(level);
   };
 
-  const handleConfirmClick = (): void => {
-    if (!selectedLevel) return;
+  const handleConfirmClick = async (): Promise<void> => {
+    if (!selectedLevel || isPending) return;
 
-    /* TODO: 학습 수준 저장 API 연동 */
-    console.log('학습 수준 선택:', selectedLevel);
-    router.push(ROUTES.HOMEPAGE);
+    try {
+      await updateGrade({targetLevel: GRADE_LABEL_TO_CODE[selectedLevel]});
+
+      if (onConfirm) {
+        onConfirm(selectedLevel);
+      } else {
+        router.push(ROUTES.HOMEPAGE);
+      }
+    } catch {
+      setIsToastVisible(true);
+    }
   };
 
-  const isButtonDisabled = selectedLevel === null;
+  const isButtonDisabled = selectedLevel === null || isPending;
 
   return (
     <div className='flex w-full flex-col gap-4'>
+      <Toast
+        variant='info'
+        position='viewport-top'
+        message='학습 수준 저장에 실패했습니다. 다시 시도해 주세요'
+        isVisible={isToastVisible}
+        onClose={() => setIsToastVisible(false)}
+      />
+
       <div className='flex w-full flex-col gap-4'>
         {DIFFICULTY_OPTIONS.map((option) => (
           <DifficultyCard
@@ -59,7 +82,7 @@ export const DifficultySelectionList = ({
         onClick={handleConfirmClick}
         disabled={isButtonDisabled}
         className='bg-primary mt-8 flex w-full items-center justify-center rounded-full px-12 py-4 text-lg font-semibold text-white shadow-[0px_10px_40px_-10px_rgba(72,84,34,0.08)] transition disabled:cursor-not-allowed disabled:opacity-50'>
-        {buttonText}
+        {isPending ? '저장 중...' : buttonText}
       </button>
     </div>
   );

--- a/src/constants/difficulty.ts
+++ b/src/constants/difficulty.ts
@@ -45,3 +45,28 @@ export const DIFFICULTY_OPTIONS: DifficultyOption[] = [
     icon: MedalIcon,
   },
 ];
+
+export type GradeCode =
+  | 'ELEM_1_2'
+  | 'ELEM_3_4'
+  | 'ELEM_5_6'
+  | 'MIDDLE_1_2'
+  | 'MIDDLE_3';
+
+/* 화면 표시용 한글 라벨 → 서버 enum 코드 (PATCH 요청 시 사용) */
+export const GRADE_LABEL_TO_CODE: Record<DifficultyLevel, GradeCode> = {
+  '초등학교 1-2학년': 'ELEM_1_2',
+  '초등학교 3-4학년': 'ELEM_3_4',
+  '초등학교 5-6학년': 'ELEM_5_6',
+  '중학교 1-2학년': 'MIDDLE_1_2',
+  '중학교 3학년': 'MIDDLE_3',
+};
+
+/* 서버 enum 코드 → 화면 표시용 한글 라벨 (GET 응답 매핑 시 사용) */
+export const GRADE_CODE_TO_LABEL: Record<GradeCode, DifficultyLevel> = {
+  ELEM_1_2: '초등학교 1-2학년',
+  ELEM_3_4: '초등학교 3-4학년',
+  ELEM_5_6: '초등학교 5-6학년',
+  MIDDLE_1_2: '중학교 1-2학년',
+  MIDDLE_3: '중학교 3학년',
+};

--- a/src/hooks/queries/useUser.ts
+++ b/src/hooks/queries/useUser.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query';
+import {getUserInfo} from '@/services/api/user/userInfoApi';
+import {patchUserGrade} from '@/services/api/user/userGradeApi';
+
+const USER_INFO_QUERY_KEY = ['userInfo'] as const;
+
+/** 내 정보 조회 (GET /api/users/me) */
+export const useUserInfo = () =>
+  useQuery({
+    queryKey: USER_INFO_QUERY_KEY,
+    queryFn: getUserInfo,
+  });
+
+/**
+ * 학습 수준 변경
+ * 성공 시 내 정보 캐시를 무효화해 변경된 학년이 즉시 반영되게 한다.
+ */
+export const useUpdateUserGradeMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchUserGrade,
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: USER_INFO_QUERY_KEY});
+    },
+  });
+};

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -161,7 +161,7 @@ export const useSignupForm = () => {
       }
     }
 
-    openModal('success', '회원가입이 완료되었습니다.', ROUTES.HOMEPAGE);
+    openModal('success', '회원가입이 완료되었습니다.', ROUTES.DIFFICULTY);
   };
 
   return {

--- a/src/services/api/user/userGradeApi.ts
+++ b/src/services/api/user/userGradeApi.ts
@@ -1,0 +1,14 @@
+/** 유저 학습 수준 수정 API 호출 함수 */
+import {api} from '@/services/lib/axios';
+import {API_ENDPOINTS} from '@/services/constant/endpoint';
+import type {GradeCode} from '@/constants/difficulty';
+
+export interface PatchUserGradeRequest {
+  targetLevel: GradeCode;
+}
+
+export const patchUserGrade = async ({
+  targetLevel,
+}: PatchUserGradeRequest): Promise<void> => {
+  await api.patch(API_ENDPOINTS.users.grade, {targetLevel});
+};

--- a/src/services/api/user/userInfoApi.ts
+++ b/src/services/api/user/userInfoApi.ts
@@ -1,0 +1,19 @@
+/** 유저 정보 조회 API 호출 함수 */
+import {api} from '@/services/lib/axios';
+import {API_ENDPOINTS} from '@/services/constant/endpoint';
+import type {GradeCode} from '@/constants/difficulty';
+
+export interface UserInfoResponse {
+  userId: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  provider: string;
+  targetLevel: GradeCode;
+  under14: boolean;
+}
+
+export const getUserInfo = async (): Promise<UserInfoResponse> => {
+  const response = await api.get<UserInfoResponse>(API_ENDPOINTS.users.me);
+  return response.data;
+};

--- a/src/services/constant/endpoint.ts
+++ b/src/services/constant/endpoint.ts
@@ -9,4 +9,8 @@ export const API_ENDPOINTS = {
     status: (speechId: number) => `/api/speech/status/${speechId}`,
     result: (speechId: number) => `/api/speech/results/${speechId}`,
   },
+  users: {
+    me: '/api/users/me',
+    grade: '/api/users/me/grade',
+  },
 };


### PR DESCRIPTION
## 🔗 관련 이슈
closes #57

## 📝 작업 내용
- 학습 수준 페이지의 조회/저장 API를 연동했습니다. 회원가입 직후 학습 수준 선택(가입 플로우)과 마이페이지의 학년 변경에서 동일하게 사용하는 GET /api/users/me, PATCH /api/users/me/grade를 React Query 기반으로 연결했습니다.
- 서버 enum 코드와 화면 표시용 한글 라벨 간 양방향 매핑을 추가해, UI는 라벨로 다루고 통신은 코드로 처리하도록 분리했습니다.
- 회원가입 완료 후 학습 수준 선택 페이지로 이동하도록 리다이렉트 경로를 수정했습니다.

## ✅ 체크리스트

### #57 학습 수준 페이지 API 연동

- [x] 학습 수준 라벨↔코드 양방향 매핑(GradeCode, GRADE_LABEL_TO_CODE, GRADE_CODE_TO_LABEL) 추가
- [x] API_ENDPOINTS에 유저 도메인(users.me, users.grade) 엔드포인트 추가
- [x] 유저 정보 조회(getUserInfo) 및 학습 수준 수정(patchUserGrade) API 호출 함수 구현 (Request/Response 타입 정의)
- [x] React Query 훅(useUserInfo, useUpdateUserGradeMutation) 구현 및 저장 성공 시 유저 정보 캐시 무효화 처리
- [x] DifficultySelectionList에 PATCH 연동: 라벨→코드 변환 후 저장, 저장 중 버튼 비활성화 + "저장 중..." 표기, 중복 제출 방지, 실패 시 토스트
- [x] 가입 플로우(기본): 학년 선택 후 저장 성공 시 홈페이지로 이동
- [x] 마이페이지: GET으로 현재 학년을 조회해 미리 선택, 저장 성공 시 마이페이지로 복귀
- [x] 마이페이지 조회 로딩/에러 분기(에러 시 재시도 버튼) 처리 및 기존 mock 제거
- [x] 회원가입 완료 후 학습 수준 선택 페이지로 이동하도록 리다이렉트 경로 수정

## 스크린샷(선택)

https://github.com/user-attachments/assets/91c1a12e-845a-4415-be1a-65d3db82f081

## 📌 비고
- 회원가입(토큰 발급) API가 아직 mock 단계라, 학습 수준 GET / PATCH는 accessToken이 있어야 동작합니다.
  - 현재는 POST /api/test/quick-signup으로 토큰을 수동 세팅해 검증했습니다.
- PATCH /api/users/me/grade는 응답 body 없이 200만 반환하므로 함수 반환 타입을 void로 처리했습니다.