### PR TITLE
[FEAT]: Pagination 적용

### DIFF
--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -16,7 +16,7 @@ type ArrowType = 'up' | 'down';
 export default function Historypage() {
   const [sortType, setSortType] = useState<SortType>('date');
   const [selectedArrow, setSelectedArrow] = useState<ArrowType>('down');
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
 
   const sortParam =
     `${sortType}_${selectedArrow === 'down' ? 'desc' : 'asc'}` as SpeechListParams['sort'];
@@ -28,16 +28,16 @@ export default function Historypage() {
 
   const handleSortTypeChange = (type: SortType) => {
     setSortType(type);
-    setCurrentPage(1);
+    setCurrentPage(0);
   };
 
   const handleArrowChange = (arrow: ArrowType) => {
     setSelectedArrow(arrow);
-    setCurrentPage(1);
+    setCurrentPage(0);
   };
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    setCurrentPage(page - 1);
     window.scrollTo({top: 0, behavior: 'smooth'});
   };
 
@@ -58,7 +58,7 @@ export default function Historypage() {
       <DetailSpeechHistoryCardList speeches={data.speeches} />
 
       <Pagination
-        currentPage={data.currentPage}
+        currentPage={data.currentPage + 1}
         totalPages={data.totalPages}
         onPageChange={handlePageChange}
       />

--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useState} from 'react';
 import {UpDownButton} from '@/components/common/buttons/UpDownButton';
 import {ToggleSegment} from '@/components/mypage/history/ToggleSegment';
 import {DetailSpeechHistoryCardList} from '@/components/mypage/history/DetailSpeechHistoryCardList';
+import {Pagination} from '@/components/common/Pagination';
 import {useSpeechList} from '@/hooks/queries/useUser';
 import {Spinner} from '@/components/common/Spinner';
 import {ErrorScreen} from '@/components/common/ErrorScreen';
+import type {SpeechListParams} from '@/services/api/user/userSpeechesApi';
 
 type SortType = 'date' | 'score';
 type ArrowType = 'up' | 'down';
@@ -14,24 +16,30 @@ type ArrowType = 'up' | 'down';
 export default function Historypage() {
   const [sortType, setSortType] = useState<SortType>('date');
   const [selectedArrow, setSelectedArrow] = useState<ArrowType>('down');
+  const [currentPage, setCurrentPage] = useState(1);
 
-  const {data, isLoading, isError} = useSpeechList();
+  const sortParam =
+    `${sortType}_${selectedArrow === 'down' ? 'desc' : 'asc'}` as SpeechListParams['sort'];
 
-  const sortedSpeeches = useMemo(() => {
-    const speeches = [...(data?.speeches ?? [])];
+  const {data, isLoading, isError} = useSpeechList({
+    page: currentPage,
+    sort: sortParam,
+  });
 
-    return speeches.sort((a, b) => {
-      if (sortType === 'date') {
-        const dateA = new Date(a.createdAt).getTime();
-        const dateB = new Date(b.createdAt).getTime();
-        return selectedArrow === 'down' ? dateB - dateA : dateA - dateB;
-      }
+  const handleSortTypeChange = (type: SortType) => {
+    setSortType(type);
+    setCurrentPage(1);
+  };
 
-      return selectedArrow === 'down'
-        ? b.averageScore - a.averageScore
-        : a.averageScore - b.averageScore;
-    });
-  }, [data?.speeches, sortType, selectedArrow]);
+  const handleArrowChange = (arrow: ArrowType) => {
+    setSelectedArrow(arrow);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({top: 0, behavior: 'smooth'});
+  };
 
   if (isLoading) return <Spinner />;
   if (isError || !data) return <ErrorScreen />;
@@ -39,14 +47,21 @@ export default function Historypage() {
   return (
     <div className='flex min-h-screen flex-col gap-8 p-6'>
       <div className='flex items-center justify-between'>
-        <ToggleSegment tab={sortType} onChange={setSortType} />
+        <ToggleSegment tab={sortType} onChange={handleSortTypeChange} />
         <UpDownButton
           selected={selectedArrow}
-          onUpClick={() => setSelectedArrow('up')}
-          onDownClick={() => setSelectedArrow('down')}
+          onUpClick={() => handleArrowChange('up')}
+          onDownClick={() => handleArrowChange('down')}
         />
       </div>
-      <DetailSpeechHistoryCardList speeches={sortedSpeeches} />
+
+      <DetailSpeechHistoryCardList speeches={data.speeches} />
+
+      <Pagination
+        currentPage={data.currentPage}
+        totalPages={data.totalPages}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,106 @@
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+function getPageNumbers(currentPage: number, totalPages: number): number[] {
+  // 5개 이하면 전체 표시
+  if (totalPages <= 5) {
+    return Array.from({length: totalPages}, (_, i) => i + 1);
+  }
+
+  // 5개 이상이면 항상 5개만 표시
+  if (currentPage <= 3) {
+    return [1, 2, 3, 4, 5];
+  }
+
+  if (currentPage >= totalPages - 2) {
+    return [
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ];
+  }
+
+  return [
+    currentPage - 2,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    currentPage + 2,
+  ];
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <nav
+      aria-label='페이지 네비게이션'
+      className='flex items-center justify-center gap-1'>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        aria-label='이전 페이지'
+        className='flex h-9 w-9 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-30'>
+        <svg
+          width='16'
+          height='16'
+          viewBox='0 0 16 16'
+          fill='none'
+          aria-hidden='true'>
+          <path
+            d='M10 12L6 8L10 4'
+            stroke='currentColor'
+            strokeWidth='1.8'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      </button>
+
+      {pageNumbers.map((page) => (
+        <button
+          key={page}
+          onClick={() => onPageChange(page)}
+          aria-label={`${page} 페이지`}
+          aria-current={currentPage === page ? 'page' : undefined}
+          className={`h-9 w-9 rounded-lg text-sm font-medium transition-colors ${
+            currentPage === page ? 'bg-primary text-white' : 'text-gray-600'
+          }`}>
+          {page}
+        </button>
+      ))}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        aria-label='다음 페이지'
+        className='flex h-9 w-9 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-30'>
+        <svg
+          width='16'
+          height='16'
+          viewBox='0 0 16 16'
+          fill='none'
+          aria-hidden='true'>
+          <path
+            d='M6 4L10 8L6 12'
+            stroke='currentColor'
+            strokeWidth='1.8'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      </button>
+    </nav>
+  );
+}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -4,34 +4,32 @@ interface PaginationProps {
   onPageChange: (page: number) => void;
 }
 
+const MAX_PAGE_BUTTONS = 5;
+
 function getPageNumbers(currentPage: number, totalPages: number): number[] {
-  // 5개 이하면 전체 표시
-  if (totalPages <= 5) {
+  // MAX_PAGE_BUTTONS개 이하면 전체 표시
+  if (totalPages <= MAX_PAGE_BUTTONS) {
     return Array.from({length: totalPages}, (_, i) => i + 1);
   }
 
-  // 5개 이상이면 항상 5개만 표시
-  if (currentPage <= 3) {
-    return [1, 2, 3, 4, 5];
+  // MAX_PAGE_BUTTONS개 이상이면 항상 MAX_PAGE_BUTTONS개만 표시
+  const half = Math.floor(MAX_PAGE_BUTTONS / 2);
+
+  if (currentPage <= half + 1) {
+    return Array.from({length: MAX_PAGE_BUTTONS}, (_, i) => i + 1);
   }
 
-  if (currentPage >= totalPages - 2) {
-    return [
-      totalPages - 4,
-      totalPages - 3,
-      totalPages - 2,
-      totalPages - 1,
-      totalPages,
-    ];
+  if (currentPage >= totalPages - half) {
+    return Array.from(
+      {length: MAX_PAGE_BUTTONS},
+      (_, i) => totalPages - (MAX_PAGE_BUTTONS - 1) + i
+    );
   }
 
-  return [
-    currentPage - 2,
-    currentPage - 1,
-    currentPage,
-    currentPage + 1,
-    currentPage + 2,
-  ];
+  return Array.from(
+    {length: MAX_PAGE_BUTTONS},
+    (_, i) => currentPage - half + i
+  );
 }
 
 export function Pagination({

--- a/src/components/mypage/history/AnimatedCard.tsx
+++ b/src/components/mypage/history/AnimatedCard.tsx
@@ -22,7 +22,7 @@ export const AnimatedCard = ({children, delay = 0}: AnimatedCardProps) => {
       }}
       viewport={{once: true}}
       transition={{
-        duration: 0.6,
+        duration: 0.4,
         delay,
         ease: 'easeOut',
       }}>

--- a/src/components/mypage/history/DetailSpeechHistoryCard.tsx
+++ b/src/components/mypage/history/DetailSpeechHistoryCard.tsx
@@ -17,7 +17,7 @@ export const DetailSpeechHistoryCard = ({
   const router = useRouter();
 
   const handleClick = () => {
-    router.push(`${ROUTES.RESULT}/${speech.speechId}`);
+    router.push(ROUTES.RESULT(speech.speechId));
   };
 
   return (

--- a/src/components/record/StatusMessage.tsx
+++ b/src/components/record/StatusMessage.tsx
@@ -14,7 +14,7 @@ export const StatusMessage = ({status}: StatusMessageProps) => {
           </>
         ) : status === 'recording' ? (
           <>
-            당신의 이야기를
+            당신의 목소리를
             <br />
             듣고 있습니다...
           </>

--- a/src/components/result/Score.tsx
+++ b/src/components/result/Score.tsx
@@ -6,7 +6,7 @@ export const Score = ({score}: ScoreProps) => {
   return (
     <section className='bg-surface flex flex-col items-center gap-6 rounded-4xl p-6'>
       <h2 className='text-primary text-sm font-extrabold tracking-wider'>
-        TOTAL SCORE
+        종합 점수
       </h2>
       <div className='border-primary flex h-36 w-36 items-center justify-center rounded-full border-9'>
         <span className='font-pretendard text-5xl font-extrabold text-black'>

--- a/src/components/stats/DailyScoreChart.tsx
+++ b/src/components/stats/DailyScoreChart.tsx
@@ -16,7 +16,7 @@ export const DailyScoreChart = ({scores, average}: DailyScoreChartProps) => {
           일별 나의 성장치
         </h3>
         <span className='font-pretendard text-primary2 rounded-2xl bg-[#EEEEE5] px-2 py-1 text-[10px] font-bold'>
-          LATEST 7 DAYS
+          최근 7일
         </span>
       </header>
 
@@ -62,11 +62,11 @@ export const DailyScoreChart = ({scores, average}: DailyScoreChartProps) => {
             aria-hidden='true'
           />
           <span className='font-pretendard text-primary2 text-sm font-medium'>
-            Daily Score Distribution
+            일별 점수 변화
           </span>
         </div>
         <span className='font-pretendard text-primary text-sm font-bold'>
-          Avg. {average}
+          평균. {average}
         </span>
       </footer>
     </section>

--- a/src/components/stats/HistoryChart.tsx
+++ b/src/components/stats/HistoryChart.tsx
@@ -78,7 +78,7 @@ export const HistoryChart = ({history}: HistoryChartProps) => {
     <section className='bg-surface border-divider/30 flex w-full flex-col gap-6 rounded-[32px] border p-6 shadow-sm'>
       <div className='flex flex-col gap-3'>
         <h3 className='text-primary text-xl font-bold tracking-[-0.32px]'>
-          성장치 히스토리
+          성장치 기록
         </h3>
 
         <ul className='flex flex-wrap gap-x-4 gap-y-2'>

--- a/src/components/stats/MasteryCard.tsx
+++ b/src/components/stats/MasteryCard.tsx
@@ -10,7 +10,7 @@ export const MasteryCard = ({metrics, overallAverage}: MasteryCardProps) => {
     <section className='bg-surface border-divider/30 flex w-full flex-col gap-6 rounded-3xl border p-6 shadow-sm'>
       <header className='flex items-start justify-between'>
         <h3 className='text-primary text-xl font-bold tracking-[-0.32px]'>
-          핵심 역량 마스터리
+          영역별 내 점수
         </h3>
         <div className='flex flex-col items-end gap-0.5'>
           <span className='font-pretendard text-primary text-3xl leading-none font-bold'>

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -12,6 +12,7 @@ import {
   useSignup,
 } from '@/hooks/queries/useAuth';
 import {AxiosError} from 'axios';
+import {removeTokens} from '@/utils/auth/token';
 
 interface ModalState {
   isOpen: boolean;
@@ -235,8 +236,10 @@ export const useSignupForm = () => {
         ...(isUnder14 && {parentEmail}),
       },
       {
-        onSuccess: () =>
-          openModal('success', '회원가입이 완료되었습니다.', ROUTES.LOGIN),
+        onSuccess: () => {
+          removeTokens();
+          openModal('success', '회원가입이 완료되었습니다.', ROUTES.LOGIN);
+        },
         onError: (error) => {
           const axiosError = error as AxiosError<{message?: string}>;
           const message = axiosError?.response?.data?.message;

--- a/src/services/api/user/userSpeechesApi.ts
+++ b/src/services/api/user/userSpeechesApi.ts
@@ -21,7 +21,7 @@ export interface UserSpeechesResponse {
 
 export interface SpeechListParams {
   page?: number;
-  sort?: 'date_desc';
+  sort?: 'date_desc' | 'date_asc' | 'score_desc' | 'score_asc';
 }
 
 export const getUserSpeeches = async (


### PR DESCRIPTION
## 🔗 관련 이슈
closes #64

## 📝 작업 내용
### `Pagination` 적용
- 기본에는 프론트에서 정렬을 처리했지만 page 별로 정렬하기 위해서는 백엔드 측 정렬이 필요하여 코드를 수정

### 회원가입 시 기본 로그인 홈페이지로 이동되는 버그 해결
- 회원가입 success 시 기본 토큰 제거

### 스피치 목록 로드되는 애니메이션 시간 간격 축소
- 로드되는 시간이 다소 길다는 피드백을 보완하여 시간 간격을 축소

### 스피치 목록 카드 클릭 시 result 페이지로 이동

## ✅ 체크리스트
- [ ] Pagination

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/a48b2f4f-e86a-4510-8905-54280e0708c6

## 💬 리뷰 요청사항 (선택)