### PR TITLE
[BUG] Azure STT 권장 규격에 맞춰 변환

### DIFF
--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -56,10 +56,22 @@ export function useRecord(): {
           const recordedBlob = new Blob(audioChunksRef.current);
           const arrayBuffer = await recordedBlob.arrayBuffer();
           const audioContext = new AudioContext();
-          const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+          const decoded = await audioContext.decodeAudioData(arrayBuffer);
           await audioContext.close();
 
-          const wavArrayBuffer = audioBufferToWav(audioBuffer);
+          const targetRate = 16000;
+          const offline = new OfflineAudioContext(
+            1, // 모노
+            Math.ceil(decoded.duration * targetRate),
+            targetRate
+          );
+          const source = offline.createBufferSource();
+          source.buffer = decoded;
+          source.connect(offline.destination);
+          source.start();
+          const rendered = await offline.startRendering();
+
+          const wavArrayBuffer = audioBufferToWav(rendered);
           const wavBlob = new Blob([wavArrayBuffer], {type: 'audio/wav'});
 
           const audioUrl = URL.createObjectURL(wavBlob);


### PR DESCRIPTION
## 🔗 관련 이슈
closes #69

## 📝 작업 내용
- Azure STT 무한 대기 버그 해결
  - 브라우저 기본 마이크 녹음 스펙(예: 48kHz, 스테레오)이 Azure STT 권장 규격과 맞지 않아 분석 단계에서 서비스가 멈추는 현상을 해결했습니다.
  - useRecord 훅의 녹음 종료 로직에 OfflineAudioContext를 도입하여, 오디오 버퍼를 16kHz, 1채널(모노)로 리샘플링 및 다운믹스하도록 수정했습니다.
  - 변환된 16kHz 모노 버퍼를 audiobuffer-to-wav를 통해 최종 WAV 파일로 생성하여 서버로 전송합니다.

## ✅ 체크리스트
- [x] 코드 셀프 리뷰 완료

## 📸 스크린샷 (선택)

## 💬 리뷰 요청사항 (선택)